### PR TITLE
Added another MIME type for directory detection

### DIFF
--- a/docs/build/html/object.html
+++ b/docs/build/html/object.html
@@ -129,7 +129,7 @@
 <dl class="method">
 <dt id="object_storage.storage_object.StorageObject.is_dir">
 <tt class="descname">is_dir</tt><big>(</big><big>)</big><a class="reference internal" href="_modules/object_storage/storage_object.html#StorageObject.is_dir"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#object_storage.storage_object.StorageObject.is_dir" title="Permalink to this definition">¶</a></dt>
-<dd><p>returns True if content_type is &#8216;text/directory&#8217;</p>
+<dd><p>returns True if content_type is &#8216;text/directory&#8217; or &#8216;application/directory&#8217;</p>
 </dd></dl>
 
 <dl class="method">

--- a/object_storage/storage_object.py
+++ b/object_storage/storage_object.py
@@ -177,7 +177,7 @@ class StorageObject:
         return self.client.make_request('GET', [self.container], params=params, formatter=_formatter)   
  
     def is_dir(self):
-        """ returns True if content_type is 'text/directory' """
+        """ returns True if content_type is 'text/directory' or 'application/directory' """
         return self.model.content_type in ['text/directory', 'application/directory']
 
     def set_metadata(self, meta):


### PR DESCRIPTION
Per OpenStack documents here: http://docs.openstack.org/trunk/openstack-object-storage/developer/content/pseudo-hierarchical-folders-directories.html

```
To take advantage of this feature, the directory marker objects must also be created to represent the appropriate directories. The following additional objects need to be created. A good convention would be to create these as zero- or one-byte files with a Content-Type of application/directory.
```

I left in the original MIME type for backwards-compatibility, but "application/directory" is the standard, and it's also how it's shown via the OpenStorage control panel.
