### PR TITLE
Fixed support for 'Range' header

### DIFF
--- a/object_storage/storage_object.py
+++ b/object_storage/storage_object.py
@@ -223,7 +223,7 @@ class StorageObject:
         """
         headers = headers or {}
 
-	_range = None
+        _range = None
 
         if size > 0:
             if not offset:


### PR DESCRIPTION
While I don't think the fix is 100% 'Pythonic', it reflects the fact that there are multiple scenarios for 'Range' header: http://docs.openstack.org/trunk/openstack-object-storage/developer/content/retrieve-object.html

I wrote a testing function that simulates this to demonstrate how it works in comparison to the above link:

``` python
>>> def tester(size=0,offset=0):
...     if size > 0:
...         if not offset:
...             print "bytes=-%d" % (size-1)
...         else:
...             print "bytes=%d-%d" % (offset, (offset+size) - 1)
...     else:
...         print "bytes=%d-" % (offset)
... 
>>> tester(offset=32)
bytes=32-
>>> tester(offset=5)
bytes=5-
>>> tester(5)
bytes=-4
>>> tester(5,10)
bytes=10-14
```
