### PR TITLE
Update README to mention that package is available via pip

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -4,7 +4,13 @@ Python bindings for SoftLayer Object Storage
 
 Installation
 ------------
-Download source and run:
+Install via pip:
+```
+sudo apt-get install python-pip
+sudo pip install softlayer-object-storage
+```
+
+Or download source and run:
 
 ```
 python setup.py install


### PR DESCRIPTION
I wasn't aware the package was available via pip at first. The README should be sure to mention this.
