### PR TITLE
Fixes exception when using is_dir on an object

### DIFF
--- a/object_storage/storage_object.py
+++ b/object_storage/storage_object.py
@@ -204,8 +204,8 @@ class StorageObject:
     def is_dir(self):
         """ returns True if content_type is 'text/directory' or
             'application/directory' """
-        return self.model.content_type in ['text/directory',
-                                           'application/directory']
+        return self.model['content_type'] in ['text/directory',
+                                              'application/directory']
 
     def update(self, headers):
         """ POSTs to the object to update metadata and other attributes

--- a/tests/test_storage_object.py
+++ b/tests/test_storage_object.py
@@ -88,6 +88,23 @@ class ClientTest(unittest.TestCase):
                                        headers=h,
                                        data='', a1=1, a2=2)
 
+    def test_object_is_dir(self):
+        dir_object = StorageObject('stuff', 'mydir',
+                                   client=self.client,
+                                   headers={'content-type':
+                                            'application/directory'})
+        legacy_dir_object = StorageObject('stuff', 'olddir',
+                                          client=self.client,
+                                          headers={'content-type':
+                                                   'text/directory'})
+        file_object = StorageObject('stuff', 'taco-recipe',
+                                    client=self.client,
+                                    headers={'content-type': 'text/taco'})
+
+        self.assertTrue(dir_object.is_dir())
+        self.assertTrue(legacy_dir_object.is_dir())
+        self.assertFalse(file_object.is_dir())
+
     def test_rename(self):
         self.obj.copy_to = Mock()
         self.obj.delete = Mock()


### PR DESCRIPTION
StorageObject wasn't properly referencing the content type within Model.

This change also adds a test to ensure this not only gets tested but
that all possible combinations of dir-like content types and a non-dir
content type yield correct results.

Closes-bug: #20
