### PR TITLE
small fix to is_dir()

### DIFF
--- a/object_storage/storage_object.py
+++ b/object_storage/storage_object.py
@@ -204,7 +204,7 @@ class StorageObject:
     def is_dir(self):
         """ returns True if content_type is 'text/directory' or
             'application/directory' """
-        return self.model['content_type'] in ['text/directory',
+        return self.properties['content_type'] in ['text/directory',
                                               'application/directory']
 
     def update(self, headers):


### PR DESCRIPTION
The `is_dir()` method was raising an unhandled exception in this code:

```
    def is_dir(self):
        """ returns True if content_type is 'text/directory' or
            'application/directory' """
        return self.model['content_type'] in ['text/directory',
                                              'application/directory']
```
First, it's possible for `self.model` to be None. Even if it's set though, such as after running `load()` the raised exception indicates StorageObjectModel instance has no attribute content_type.

The fix simply accesses the `properties` dictionary.