### PR TITLE
Updates DC list and allows unknown DC designators

### DIFF
--- a/object_storage/__init__.py
+++ b/object_storage/__init__.py
@@ -72,8 +72,3 @@ def get_twisted_client(username, password,
 
     d = conn.authenticate().addCallback(lambda r: client)
     return d
-
-__all__ = ['get_client',
-           'get_httplib2_client',
-           'get_requests_client',
-           'get_twisted_client']

--- a/object_storage/consts.py
+++ b/object_storage/consts.py
@@ -4,12 +4,34 @@
     See COPYING for license information
 """
 
-__version__ = "0.5.2"
+
+__version__ = "0.5.3"
 
 USER_AGENT = "sl-object-storage-python/%s" % __version__
 
+DATACENTERS = [
+    'dal05',  # US - Texas - Dallas
+    'ams01',  # NL - North Holland - Amsterdam
+    'sng01',  # SG - Singapore
+    'sjc01',  # US - California - San Jose
+    'hkg02',  # HK - Hong Kong
+    'lon02',  # GB - London
+    'tor01',  # CA - Ontario - Toronto
+    'mel01',  # AU - Victoria - Melbourne
+    'par01',  # FR - Paris
+    'mex01',  # MX - Mexico City
+    'tok02',  # JP - Tokyo
+    'fra02',  # DE - Hesse - Frankfurt
+    'syd01',  # AU - New South Wales - Sydney
+    'mon01',  # CA - Quebec - Montreal
+]
 
-def _dc_endpoints(dc):
+PUBLIC_SUFFIX = 'objectstorage.softlayer.net'
+PRIVATE_SUFFIX = 'objectstorage.service.networklayer.com'
+
+
+def dc_endpoints(dc):
+    dc = dc.lower()
     return {
         'public': {
             'http': 'http://%s.%s/auth/v1.0' % (dc, PUBLIC_SUFFIX),
@@ -21,19 +43,6 @@ def _dc_endpoints(dc):
         }
     }
 
-DATACENTERS = ['dal05',  # US - Texas - Dallas
-               'ams01',  # NL - North Holland - Amsterdam
-               'sng01',  # SG - Singapore
-               'sjc01',  # US - California - San Jose
-               'hkg02',  # HK - Hong Kong
-               'lon02',  # GB - London
-               'tor01',  # CA - Ontario - Toronto
-               'mel01',  # AU - Victoria - Melbourne
-               'par01']  # FR - Paris
-
-PUBLIC_SUFFIX = 'objectstorage.softlayer.net'
-PRIVATE_SUFFIX = 'objectstorage.service.networklayer.com'
-
 # Normally this could be a dict comprehension, but we're maintaining
 # compatibility with Python 2.6, so the slower dict() is necessary.
-ENDPOINTS = dict((dc, _dc_endpoints(dc)) for dc in DATACENTERS)
+ENDPOINTS = dict((dc, dc_endpoints(dc)) for dc in DATACENTERS)

--- a/object_storage/transport/__init__.py
+++ b/object_storage/transport/__init__.py
@@ -6,11 +6,12 @@
 import httplib
 from socket import timeout
 from urlparse import urlparse
-from object_storage.errors import ResponseError, NotFound
-from object_storage import consts
 
 import urllib2
 import re
+
+from object_storage.errors import ResponseError, NotFound
+from object_storage import consts
 
 
 class Response(object):
@@ -85,9 +86,14 @@ class BaseAuthentication(object):
         self.use_default_storage_url = True
         if not auth_url:
             self.use_default_storage_url = False
-            self.auth_url = consts.ENDPOINTS.get(self.datacenter) \
-                                            .get(self.network) \
-                                            .get(self.protocol)
+            dc_endpoints = consts.ENDPOINTS.get(self.datacenter)
+
+            if not dc_endpoints:
+                dc_endpoints = consts.dc_endpoints(self.datacenter)
+
+            self.auth_url = dc_endpoints.get(self.network) \
+                                        .get(self.protocol)
+
         self.storage_url = None
         self.auth_token = None
         self.authenticated = False


### PR DESCRIPTION
Now, rather than raising an index error when a DC designator cannot be
found, we go ahead and try to use the provided DC name to construct the
auth URL anyway. This at least allows Swift in new DCs to be used
without it needing to exist in the DC dict. Folks won't necessarily
have to upgrade this package just to add new DCs.

This doesn't fully remove the object_storage.DATACENTERS dict since
someone could conceivably be referencing this list for something -- but
it will be deprecated as constructing on the fly removes the need for
these to be pre-defined.